### PR TITLE
Allow installation under PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "nunomaduro/phpinsights": "^2.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^8.3 || ^9.0",
         "symfony/var-dumper": "^5.0",
         "vimeo/psalm": "^4.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
-        "nunomaduro/phpinsights": "^1.11",
-        "phpunit/phpunit": "^8.3",
+        "nunomaduro/phpinsights": "^2.0",
+        "phpunit/phpunit": "^9.0",
         "symfony/var-dumper": "^5.0",
         "vimeo/psalm": "^4.6"
     },

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -21,11 +21,10 @@ final class Listener
         $reflectionParameter = $this->extractReflectionParameter($callable);
 
         $reflectionType = $reflectionParameter->getType();
-        if ($reflectionType !== null) {
-            $this->type = $reflectionType->getName();
-            if ($this->type !== 'object' && $reflectionParameter->getClass() === null) {
-                throw new InvalidListener($callable);
-            }
+        assert($reflectionType instanceof \ReflectionNamedType);
+        $this->type = $reflectionType->getName();
+        if ($this->type !== 'object' && !class_exists($this->type)) {
+            throw new InvalidListener($callable);
         }
 
         $this->alwaysMatching = \in_array($this->type, [null, 'object'], true);

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -23,7 +23,7 @@ final class Listener
         $reflectionType = $reflectionParameter->getType();
         assert($reflectionType instanceof \ReflectionNamedType);
         $this->type = $reflectionType->getName();
-        if ($this->type !== 'object' && !class_exists($this->type)) {
+        if (!$this->isValidType($this->type)) {
             throw new InvalidListener($callable);
         }
 
@@ -51,5 +51,13 @@ final class Listener
         }
 
         return $reflectionParameter;
+    }
+
+    private function isValidType(string $type):bool
+    {
+        if ($type === 'object') {
+            return true;
+        }
+        return class_exists($type) || interface_exists($type);
     }
 }


### PR DESCRIPTION
Hello, this is a little version bump that allows consuming this package with PHP8.

There is one failing test that does not seem to be related to the language version ([`is_object` takes `mixed` as a parameter and the Listener cannot deal with that which makes sense](https://github.com/Lium-Framework/event-dispatcher/blob/b5a60130eeb5a77af90af56e08218034ab658890/tests/ListenerTest.php#L17)). So I left that untouched for now.